### PR TITLE
Update elasticsearch cases build instructions

### DIFF
--- a/elasticsearch/0404db65e3497452886173957729c8e82cfd4a03/README.md
+++ b/elasticsearch/0404db65e3497452886173957729c8e82cfd4a03/README.md
@@ -1,4 +1,4 @@
-1. Clone the project:  
+1. Clone the project:
    `git clone https://github.com/elastic/elasticsearch`
 2. Checkout to merge commit hash:  
    `git checkout 0404db65e3497452886173957729c8e82cfd4a03`
@@ -12,4 +12,5 @@
    * Configure your path so that you can execute the gradle command
       `export PATH=$PATH:/opt/gradle/gradle-2.8/bin`
 5. With gradle on version 2.8, execute:
-   `gradle assemble testClasses`
+  `gradle assemble testClasses`
+6. Execute the command `find . -name "*.jar"` to list the generated jars and copy them to the destination folder.

--- a/elasticsearch/0404db65e3497452886173957729c8e82cfd4a03/README.md
+++ b/elasticsearch/0404db65e3497452886173957729c8e82cfd4a03/README.md
@@ -2,5 +2,13 @@
    `git clone https://github.com/elastic/elasticsearch`
 2. Checkout to merge commit hash:  
    `git checkout 0404db65e3497452886173957729c8e82cfd4a03`
-3. With gradle on version 2.8, execute:
+3. Execute the following steps to install gradle version 2.8:
+   * Download the "complete" option for the release 2.8 in the [Gradle Releases Page](https://gradle.org/releases/)
+   * Create a directory for the gradle installation
+      `mkdir /opt/gradle`
+   * Unzip the downloaded file on the installation directory
+      `unzip -d /opt/gradle gradle-2.8-all.zip`
+   * Configure your path so that you can execute the gradle command
+      `export PATH=$PATH:/opt/gradle/gradle-2.8/bin`
+4. With gradle on version 2.8, execute:
    `gradle assemble testClasses`

--- a/elasticsearch/0404db65e3497452886173957729c8e82cfd4a03/README.md
+++ b/elasticsearch/0404db65e3497452886173957729c8e82cfd4a03/README.md
@@ -2,7 +2,8 @@
    `git clone https://github.com/elastic/elasticsearch`
 2. Checkout to merge commit hash:  
    `git checkout 0404db65e3497452886173957729c8e82cfd4a03`
-3. Execute the following steps to install gradle version 2.8:
+3. Install Java 8 locally
+4. Execute the following steps to install gradle version 2.8:
    * Download the "complete" option for the release 2.8 in the [Gradle Releases Page](https://gradle.org/releases/)
    * Create a directory for the gradle installation
       `mkdir /opt/gradle`
@@ -10,5 +11,5 @@
       `unzip -d /opt/gradle gradle-2.8-all.zip`
    * Configure your path so that you can execute the gradle command
       `export PATH=$PATH:/opt/gradle/gradle-2.8/bin`
-4. With gradle on version 2.8, execute:
+5. With gradle on version 2.8, execute:
    `gradle assemble testClasses`

--- a/elasticsearch/3764b3ff800c94293aba0bb0fa18c7df80a764f7/README.md
+++ b/elasticsearch/3764b3ff800c94293aba0bb0fa18c7df80a764f7/README.md
@@ -1,6 +1,14 @@
 1. Clone the project:  
    `git clone https://github.com/elastic/elasticsearch`
 2. Checkout to merge commit hash:  
-   `git checkout 36884807b3cc9d660db4da062275c7fdbec8ba67`
-3. With gradle on version 2.8, execute:
+   `git checkout 3764b3ff800c94293aba0bb0fa18c7df80a764f7`
+3. Execute the following steps to install gradle version 2.8:
+   * Download the "complete" option for the release 2.8 in the [Gradle Releases Page](https://gradle.org/releases/)
+   * Create a directory for the gradle installation
+      `mkdir /opt/gradle`
+   * Unzip the downloaded file on the installation directory
+      `unzip -d /opt/gradle gradle-2.8-all.zip`
+   * Configure your path so that you can execute the gradle command
+      `export PATH=$PATH:/opt/gradle/gradle-2.8/bin`
+4. With gradle on version 2.8, execute:
    `gradle assemble testClasses`

--- a/elasticsearch/3764b3ff800c94293aba0bb0fa18c7df80a764f7/README.md
+++ b/elasticsearch/3764b3ff800c94293aba0bb0fa18c7df80a764f7/README.md
@@ -13,3 +13,4 @@
       `export PATH=$PATH:/opt/gradle/gradle-2.8/bin`
 5. With gradle on version 2.8, execute:
    `gradle assemble testClasses`
+6. Execute the command `find . -name "*.jar"` to list the generated jars and copy them to the destination folder.

--- a/elasticsearch/3764b3ff800c94293aba0bb0fa18c7df80a764f7/README.md
+++ b/elasticsearch/3764b3ff800c94293aba0bb0fa18c7df80a764f7/README.md
@@ -2,7 +2,8 @@
    `git clone https://github.com/elastic/elasticsearch`
 2. Checkout to merge commit hash:  
    `git checkout 3764b3ff800c94293aba0bb0fa18c7df80a764f7`
-3. Execute the following steps to install gradle version 2.8:
+3. Install Java 8 locally
+4. Execute the following steps to install gradle version 2.8:
    * Download the "complete" option for the release 2.8 in the [Gradle Releases Page](https://gradle.org/releases/)
    * Create a directory for the gradle installation
       `mkdir /opt/gradle`
@@ -10,5 +11,5 @@
       `unzip -d /opt/gradle gradle-2.8-all.zip`
    * Configure your path so that you can execute the gradle command
       `export PATH=$PATH:/opt/gradle/gradle-2.8/bin`
-4. With gradle on version 2.8, execute:
+5. With gradle on version 2.8, execute:
    `gradle assemble testClasses`

--- a/elasticsearch/c1d44780675a9ff43e87a44f62969a0214928988/README.md
+++ b/elasticsearch/c1d44780675a9ff43e87a44f62969a0214928988/README.md
@@ -2,5 +2,14 @@
    `git clone https://github.com/elastic/elasticsearch`
 2. Checkout to merge commit hash:  
    `git checkout c1d44780675a9ff43e87a44f62969a0214928988`
-3. With gradle on version 2.13, execute:
+3. Install Java 8 locally
+4. Execute the following steps to install gradle version 2.13:
+   * Download the "complete" option for the release 2.13 in the [Gradle Releases Page](https://gradle.org/releases/)
+   * Create a directory for the gradle installation
+      `mkdir /opt/gradle`
+   * Unzip the downloaded file on the installation directory
+      `unzip -d /opt/gradle gradle-2.13-all.zip`
+   * Configure your path so that you can execute the gradle command
+      `export PATH=$PATH:/opt/gradle/gradle-2.13/bin`
+5. With gradle on version 2.8, execute:
    `gradle assemble testClasses`

--- a/elasticsearch/c1d44780675a9ff43e87a44f62969a0214928988/README.md
+++ b/elasticsearch/c1d44780675a9ff43e87a44f62969a0214928988/README.md
@@ -13,3 +13,4 @@
       `export PATH=$PATH:/opt/gradle/gradle-2.13/bin`
 5. With gradle on version 2.8, execute:
    `gradle assemble testClasses`
+6. Execute the command `find . -name "*.jar"` to list the generated jars and copy them to the destination folder.

--- a/elasticsearch/d896886973660785aac45275ddb110c1a6babc57/README.md
+++ b/elasticsearch/d896886973660785aac45275ddb110c1a6babc57/README.md
@@ -2,5 +2,13 @@
    `git clone https://github.com/elastic/elasticsearch`
 2. Checkout to merge commit hash:  
    `git checkout d896886973660785aac45275ddb110c1a6babc57`
-3. With gradle on version 2.13, execute:
+3. Execute the following steps to install gradle version 2.13:
+   * Download the "complete" option for the release 2.13 in the [Gradle Releases Page](https://gradle.org/releases/)
+   * Create a directory for the gradle installation
+      `mkdir /opt/gradle`
+   * Unzip the downloaded file on the installation directory
+      `unzip -d /opt/gradle gradle-2.13-all.zip`
+   * Configure your path so that you can execute the gradle command
+      `export PATH=$PATH:/opt/gradle/gradle-2.13/bin`
+4. With gradle on version 2.8, execute:
    `gradle assemble testClasses`

--- a/elasticsearch/d896886973660785aac45275ddb110c1a6babc57/README.md
+++ b/elasticsearch/d896886973660785aac45275ddb110c1a6babc57/README.md
@@ -2,7 +2,8 @@
    `git clone https://github.com/elastic/elasticsearch`
 2. Checkout to merge commit hash:  
    `git checkout d896886973660785aac45275ddb110c1a6babc57`
-3. Execute the following steps to install gradle version 2.13:
+3. Install Java 8 locally
+4. Execute the following steps to install gradle version 2.13:
    * Download the "complete" option for the release 2.13 in the [Gradle Releases Page](https://gradle.org/releases/)
    * Create a directory for the gradle installation
       `mkdir /opt/gradle`
@@ -10,5 +11,5 @@
       `unzip -d /opt/gradle gradle-2.13-all.zip`
    * Configure your path so that you can execute the gradle command
       `export PATH=$PATH:/opt/gradle/gradle-2.13/bin`
-4. With gradle on version 2.8, execute:
+5. With gradle on version 2.8, execute:
    `gradle assemble testClasses`

--- a/elasticsearch/d896886973660785aac45275ddb110c1a6babc57/README.md
+++ b/elasticsearch/d896886973660785aac45275ddb110c1a6babc57/README.md
@@ -13,3 +13,4 @@
       `export PATH=$PATH:/opt/gradle/gradle-2.13/bin`
 5. With gradle on version 2.8, execute:
    `gradle assemble testClasses`
+6. Execute the command `find . -name "*.jar"` to list the generated jars and copy them to the destination folder.


### PR DESCRIPTION
Included the steps to install Gradle versions on the elasticsearch cases and fixed a git checkout instruction that had the wrong commit hash.